### PR TITLE
Enable splitting transcripts in chunks

### DIFF
--- a/index.js
+++ b/index.js
@@ -262,20 +262,17 @@ async function splitTranscript(transcript, maxTokens) {
   const chunks = [];
 
   for (let i = 0; i < tokens.length;) {
-    let end = i + maxTokens;
-    while (end < tokens.length && tokens[end] !== encode('. ')[0]) {
+    let end = Math.min(i + maxTokens, tokens.length);
+    while (end > i && tokens[end - 1] !== encode('. ')[0]) {
       end--;
     }
-    if (end >= tokens.length) {
-      end = tokens.length - 1;
-    } else {
-      end++; // To include the full stop in the chunk
+    if (end <= i) {
+      end = Math.min(i + maxTokens, tokens.length); // Fallback if no full stop is found
     }
-
     const chunkTokens = tokens.slice(i, end);
     const chunkText = decode(chunkTokens);
     chunks.push(chunkText);
-    i = end;
+    i = end + 1;
   }
 
   return chunks;

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ const TMP_DOWNLOADS = './tmp_downloads';
 
 const logger = (message) => process.env.DEBUG_LOGS && console.log(message)
 
-const CHUNK_SUMMARIZATION = false;
+const CHUNK_SUMMARIZATION = true;
 
 if (!YOUTUBE_URL) {
   console.error('Please provide a YouTube URL as a command-line argument.');


### PR DESCRIPTION
This fixes infinite looping when splitting a transcript into chunks.

I asked ChatGPT for help with this one because I'm bad at off-by-one errors and this bug had the distinct smell of an
off-by-one error.

It might be good to add some tests, but that would require separating the main program from the utility functions, which is work we better save for a later commit.
